### PR TITLE
TSP: Tech Print Origin Improvements and Fixes (Emergency Hot Fix)

### DIFF
--- a/1.4/Patches/TSP_ResearchFlavor.xml
+++ b/1.4/Patches/TSP_ResearchFlavor.xml
@@ -4,8 +4,8 @@
 	<Operation Class="PatchOperationConditional">
 	<!-- Does this exist? -->
 	<xpath>/Defs/FactionDef[defName="Empire"]</xpath>
-		<!-- If it does, inset this in the same qualifier as the target. -->
-		<match Class="PatchOperationAdd">
+		<!-- If it does, insert this in the same qualifier as the target. -->
+		<match Class="PatchOperationInsert">
 			<success>Always</success>
 			<xpath>/Defs/ResearchProjectDef/heldByFactionCategoryTags/li[text()="Empire"]</xpath>
 			<value>
@@ -19,8 +19,8 @@
 	<Operation Class="PatchOperationConditional">
 	<!-- Does this exist? -->
 	<xpath>/Defs/FactionDef[defName="TribeCivil"]</xpath>
-		<!-- If it does, inset this in the same qualifier as the target. -->
-		<match Class="PatchOperationAdd">
+		<!-- If it does, insert this in the same qualifier as the target. -->
+		<match Class="PatchOperationInsert">
 			<success>Always</success>
 			<xpath>/Defs/ResearchProjectDef/heldByFactionCategoryTags/li[text()="Tribal"]</xpath>
 			<value>
@@ -33,8 +33,8 @@
 	<Operation Class="PatchOperationConditional">
 	<!-- Does this exist? -->
 	<xpath>/Defs/FactionDef[defName="Ancients"]</xpath>
-		<!-- If it does, inset this in the same qualifier as the target. -->
-		<match Class="PatchOperationAdd">
+		<!-- If it does, insert this in the same qualifier as the target. -->
+		<match Class="PatchOperationInsert">
 			<success>Always</success>
 			<xpath>/Defs/ResearchProjectDef/heldByFactionCategoryTags/li[text()="Ancient"]</xpath>
 			<value>

--- a/1.4/Patches/TSP_ResearchFlavor.xml
+++ b/1.4/Patches/TSP_ResearchFlavor.xml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationConditional">
+	<!-- Does this exist? -->
+	<xpath>/Defs/FactionDef[defName="Empire"]</xpath>
+		<!-- If it does, inset this in the same qualifier as the target. -->
+		<match Class="PatchOperationAdd">
+			<success>Always</success>
+			<xpath>/Defs/ResearchProjectDef/heldByFactionCategoryTags/li[text()="Empire"]</xpath>
+			<value>
+				<li MayRequire="morph.frx.teleportermain">UnknownFaction</li>
+				<li>Egypt</li> <!-- How else could they build the pyramids? -->
+			</value>
+		</match>
+		<!-- If the first XPATH does not exist, the original code stands. -->
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+	<!-- Does this exist? -->
+	<xpath>/Defs/FactionDef[defName="TribeCivil"]</xpath>
+		<!-- If it does, inset this in the same qualifier as the target. -->
+		<match Class="PatchOperationAdd">
+			<success>Always</success>
+			<xpath>/Defs/ResearchProjectDef/heldByFactionCategoryTags/li[text()="Tribal"]</xpath>
+			<value>
+				<li>Egypt</li>
+			</value>
+		</match>
+		<!-- If the first XPATH does not exist, the original code stands. -->
+	</Operation>
+	
+	<Operation Class="PatchOperationConditional">
+	<!-- Does this exist? -->
+	<xpath>/Defs/FactionDef[defName="Ancients"]</xpath>
+		<!-- If it does, inset this in the same qualifier as the target. -->
+		<match Class="PatchOperationAdd">
+			<success>Always</success>
+			<xpath>/Defs/ResearchProjectDef/heldByFactionCategoryTags/li[text()="Ancient"]</xpath>
+			<value>
+				<li MayRequire="morph.frx.teleportermain">UnknownFaction</li>
+				<li>Egypt</li> <!-- How else could they build the pyramids? -->
+			</value>
+		</match>
+		<!-- If the first XPATH does not exist, the original code stands. -->
+	</Operation>
+</Patch>


### PR DESCRIPTION
This is a very minor change to a Patch. Rather than using the correct PATCHOPERATIONINSERT command, I used PATCHOPERATIONADD, which broke the generation of Tech Prints across the board. This quick Hot Fix should solve this oversight.